### PR TITLE
Add DOCX import support

### DIFF
--- a/app/src/main/java/com/example/testapp/presentation/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/example/testapp/presentation/screen/SettingsScreen.kt
@@ -427,12 +427,14 @@ fun SettingsScreen(
             arrayOf(
                 "application/vnd.ms-excel",
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                "text/plain"
+                "text/plain",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "application/msword"
             )
         )
         }) {
             Text(
-                "导入题库文件（支持xls/xlsx/txt）",
+                "导入题库文件（支持xls/xlsx/txt/docx）",
                 style = MaterialTheme.typography.bodyLarge.copy(
                     fontSize = fontSize.sp,
                     fontFamily = LocalFontFamily.current


### PR DESCRIPTION
## Summary
- support docx question import in repository
- update settings screen to allow selecting docx files

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6878dfe1a38883249c55d7d93012d015